### PR TITLE
fix: Update deepdiff dependency to 8.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deepdiff==8.0.1
+deepdiff==8.6.1
 maxminddb==2.6.2
 mmdb_writer==0.2.5
 mrtparse==2.2.0


### PR DESCRIPTION
This should address the concerns around CVE-2025-58367 [1]

[1] https://nvd.nist.gov/vuln/detail/CVE-2025-58367